### PR TITLE
Fix hideothersubsections option

### DIFF
--- a/{{cookiecutter.repo_name}}/main.tex
+++ b/{{cookiecutter.repo_name}}/main.tex
@@ -150,7 +150,7 @@ morekeywords={xmlns,version,type}
 {
   \begin{frame}<beamer>
     \frametitle{Contents}
-    \scriptsize\tableofcontents[currentsection,hideothersubsection]
+    \scriptsize\tableofcontents[currentsection,hideothersubsections]
   \end{frame}
 }
 


### PR DESCRIPTION
I couldn't compile the project, seems to me that this is just a typo. Maybe this option changed on recent versions?

Anyways, after making this change it works and I can get the beamer pdf by just running `make`. 